### PR TITLE
Upgrade speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ disablewallet=1
 # [ZeroMQ]
 # ZeroMQ messages power the realtime BitDB crawler
 # so it's important to set the endpoint
-zmqpubhashtx=tcp://127.0.0.1:28332
+zmqpubrawtx=tcp://127.0.0.1:28332
 zmqpubhashblock=tcp://127.0.0.1:28332
 
 # BitDB makes heavy use of JSON-RPC so it's set to a higher number

--- a/bit.js
+++ b/bit.js
@@ -85,14 +85,14 @@ const crawl = async function(block_index) {
 
   let btxs = []
   for (let tx of block.transactions) {
-    let tna = await TNA.fromTx(tx.toString())
-   tna.blk = {
-     i: block_index,
-     h: block.header.hash,
-     t: block.header.time
-   }
+    let tna = await TNA.fromGene(tx)
+    tna.blk = {
+      i: block_index,
+      h: block.header.hash,
+      t: block.header.time
+    }
 
-   btxs.push(tna)
+    btxs.push(tna)
   }
 
   console.log('Block ' + block_index + ' : ' + btxs.length + 'txs')

--- a/bit.js
+++ b/bit.js
@@ -167,7 +167,9 @@ const sync = async function(type, hash) {
 
         // zmq broadcast
         let b = { i: index, txs: content }
-        console.log('Zmq block = ', JSON.stringify(b, null, 2))
+        if (Config.core.verbose) {
+          console.log('Zmq block = ', JSON.stringify(b, null, 2))
+        }
         outsock.send(['block', JSON.stringify(b)])
       }
 

--- a/bit.js
+++ b/bit.js
@@ -103,7 +103,7 @@ const outsock = zmq.socket('pub')
 const listen = function() {
   let sock = zmq.socket('sub')
   sock.connect('tcp://' + Config.zmq.incoming.host + ':' + Config.zmq.incoming.port)
-  sock.subscribe('hashtx')
+  sock.subscribe('rawtx')
   sock.subscribe('hashblock')
   console.log('Subscriber connected to port ' + Config.zmq.incoming.port)
 
@@ -112,101 +112,102 @@ const listen = function() {
 
   // Listen to ZMQ
   sock.on('message', async function(topic, message) {
-    if (topic.toString() === 'hashtx') {
-      let hash = message.toString('hex')
-      console.log('New mempool hash from ZMQ = ', hash)
-      await sync('mempool', hash)
+    if (topic.toString() === 'rawtx') {
+      let rawtx = message.toString('hex')
+      console.log('New transaction from ZMQ')
+      await handle_zmq_tx(rawtx)
     } else if (topic.toString() === 'hashblock') {
       let hash = message.toString('hex')
       console.log('New block hash from ZMQ = ', hash)
-      await sync('block')
+      await handle_zmq_block()
     }
   })
 
   // Don't trust ZMQ. Try synchronizing every 1 minute in case ZMQ didn't fire
   setInterval(async function() {
-    await sync('block')
+    await handle_zmq_block()
   }, 60000)
-
 }
 
-const sync = async function(type, hash) {
-  if (type === 'block') {
-    try {
-      const lastSynchronized = await Info.checkpoint()
-      const currentHeight = await request.height()
-      console.log('Last Synchronized = ', lastSynchronized)
-      console.log('Current Height = ', currentHeight)
+const handle_zmq_block = async function() {
+  try {
+    const lastSynchronized = await Info.checkpoint()
+    const currentHeight = await request.height()
+    console.log('Last Synchronized = ', lastSynchronized)
+    console.log('Current Height = ', currentHeight)
 
-      for(let index=lastSynchronized+1; index<=currentHeight; index++) {
-        console.log('RPC BEGIN ' + index, new Date().toString())
-        console.time('RPC END ' + index)
-        let content = await crawl(index)
-        console.timeEnd('RPC END ' + index)
-        console.log(new Date().toString())
-        console.log('DB BEGIN ' + index, new Date().toString())
-        console.time('DB Insert ' + index)
+    for(let index=lastSynchronized+1; index<=currentHeight; index++) {
+      console.log('RPC BEGIN ' + index, new Date().toString())
+      console.time('RPC END ' + index)
+      let content = await crawl(index)
+      console.timeEnd('RPC END ' + index)
+      console.log(new Date().toString())
+      console.log('DB BEGIN ' + index, new Date().toString())
+      console.time('DB Insert ' + index)
 
-        await Db.block.insert(content, index)
+      await Db.block.insert(content, index)
 
-        await Info.updateTip(index)
-        console.timeEnd('DB Insert ' + index)
-        console.log('------------------------------------------')
-        console.log('\n')
+      await Info.updateTip(index)
+      console.timeEnd('DB Insert ' + index)
+      console.log('------------------------------------------')
+      console.log('\n')
 
-        // zmq broadcast
-        let b = { i: index, txs: content }
-        if (Config.core.verbose) {
-          console.log('Zmq block = ', JSON.stringify(b, null, 2))
-        }
-        outsock.send(['block', JSON.stringify(b)])
+      // zmq broadcast
+      let b = { i: index, txs: content }
+      if (Config.core.verbose) {
+        console.log('Zmq block = ', JSON.stringify(b, null, 2))
       }
-
-      // clear mempool and synchronize
-      if (lastSynchronized < currentHeight) {
-        console.log('Clear mempool and repopulate')
-        let items = await request.mempool()
-        await Db.mempool.sync(items)
-      }
-
-      if (lastSynchronized === currentHeight) {
-        console.log('no update')
-        return null
-      } else {
-        console.log('[finished]')
-        return currentHeight
-      }
-    } catch (e) {
-      console.log('Error', e)
-      console.log('Shutting down Bitdb...', new Date().toString())
-      await Db.exit()
-      process.exit()
+      outsock.send(['block', JSON.stringify(b)])
     }
-  } else if (type === 'mempool') {
-    queue.add(async function() {
-      let content = await request.tx(hash)
-      try {
-        await Db.mempool.insert(content)
-        console.log('# Q inserted [size: ' + queue.size + ']',  hash)
-        console.log(content)
-        outsock.send(['mempool', JSON.stringify(content)])
-      } catch (e) {
-        // duplicates are ok because they will be ignored
-        if (e.code == 11000) {
-          console.log('Duplicate mempool item: ', content)
-        } else {
-          console.log('## ERR ', e, content)
-          process.exit()
-        }
-      }
-    })
-    return hash
+
+    // clear mempool and synchronize
+    if (lastSynchronized < currentHeight) {
+      console.log('Clear mempool and repopulate')
+      let items = await request.mempool()
+      await Db.mempool.sync(items)
+    }
+
+    if (lastSynchronized === currentHeight) {
+      console.log('no update')
+      return null
+    } else {
+      console.log('[finished]')
+      return currentHeight
+    }
+  } catch (e) {
+    console.log('Error', e)
+    console.log('Shutting down Bitdb...', new Date().toString())
+    await Db.exit()
+    process.exit()
   }
+}
+
+const handle_zmq_tx = async function(rawtx) {
+  queue.add(async function() {
+    let tx = new bch.Transaction(rawtx);
+    let tna = await TNA.fromGene(tx);
+    try {
+      await Db.mempool.insert(tna)
+      console.log('# Q inserted [size: ' + queue.size + ']',  tna.tx.h)
+      if (Config.core.verbose) {
+        console.log(tna)
+      }
+      outsock.send(['mempool', JSON.stringify(tna)])
+    } catch (e) {
+      // duplicates are ok because they will be ignored
+      if (e.code == 11000) {
+        console.log('Duplicate mempool item: ', tna.tx.h)
+      } else {
+        console.log('## ERR ', e, tna)
+        process.exit()
+      }
+    }
+  })
 }
 const run = async function() {
 
   // initial block sync
-  await sync('block')
+  await handle_zmq_block()
 
   // initial mempool sync
   console.log('Clear mempool and repopulate')
@@ -214,5 +215,5 @@ const run = async function() {
   await Db.mempool.sync(items)
 }
 module.exports = {
-  init: init, crawl: crawl, listen: listen, sync: sync, run: run
+  init: init, crawl: crawl, listen: listen, run: run
 }

--- a/config.js
+++ b/config.js
@@ -48,6 +48,7 @@ module.exports = {
   },
   'core': {
     'version': '0.2.0',
-    'from': Number.parseInt(process.env.core_from ? process.env.core_from : 525470)
+    'from': Number.parseInt(process.env.core_from ? process.env.core_from : 525470),
+    'verbose': process.env.core_verbose ? process.env.core_verbose : false
   }
 }

--- a/db.js
+++ b/db.js
@@ -167,7 +167,7 @@ var block = {
       let result = await db.collection('confirmed').indexInformation({full: true})
       console.log('* Confirmed Index = ', result)
       result = await db.collection('unconfirmed').indexInformation({full: true})
-      console.log('* Unonfirmed Index = ', result)
+      console.log('* Unconfirmed Index = ', result)
     } catch (e) {
       console.log('* Error fetching index info ', e)
       process.exit()

--- a/package-lock.json
+++ b/package-lock.json
@@ -2378,9 +2378,9 @@
       }
     },
     "fountainhead-tna": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/fountainhead-tna/-/fountainhead-tna-0.1.5.tgz",
-      "integrity": "sha512-8mk+JCLPXseBa6GhZzHL8yL8rx7uc62d60ThaKdGA2K+wow8CMgTMmxtDw6y+4WEWNU/mivD0mp0uQ7OWTXGKA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fountainhead-tna/-/fountainhead-tna-0.1.6.tgz",
+      "integrity": "sha512-VTklDndkpp2kIQtCjRaztr/OxiExfvzOHvWhruBIrYEHvKMrWFCoLe77BrPrXJNIgHXYzlgc4uFFSvv0ibPsUw==",
       "requires": {
         "bitcoind-rpc": "^0.7.2",
         "bitcore-lib-cash": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fountainhead-bitd",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountainhead-bitd",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "decentralized autonomous database over bitcoin",
   "main": "index.js",
   "author": "21 Century Motor Company",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "lint": "./node_modules/.bin/eslint ."
   },
   "dependencies": {
+    "bitcoind-rpc": "^0.7.2",
+    "bitcore-lib-cash": "^0.19.0",
+    "dotenv": "^6.0.0",
     "fountainhead-bcode": "0.0.6",
     "fountainhead-bigjq": "0.0.13",
-    "bitcoind-rpc": "^0.7.2",
-    "dotenv": "^6.0.0",
+    "fountainhead-tna": "0.1.5",
     "iconv-lite": "^0.4.24",
     "ip": "^1.1.5",
     "level": "^4.0.0",
@@ -21,7 +23,6 @@
     "mongodb": "^3.1.4",
     "p-limit": "^2.0.0",
     "p-queue": "^3.0.0",
-    "fountainhead-tna": "0.1.5",
     "traverse": "^0.6.6",
     "zeromq": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^6.0.0",
     "fountainhead-bcode": "0.0.6",
     "fountainhead-bigjq": "0.0.13",
-    "fountainhead-tna": "0.1.5",
+    "fountainhead-tna": "0.1.6",
     "iconv-lite": "^0.4.24",
     "ip": "^1.1.5",
     "level": "^4.0.0",


### PR DESCRIPTION
This has the crawler not look up every tx, but instead gets the raw block data and extracts the transactions from there. 

Look at the new PR in the tna repo as well to see the fromGene part.

It also modifies how mempool transactions come in. We now listen for the raw transaction data, this allows us to avoid a rpc call - I think this will be useful when there are 100+tx/s.  